### PR TITLE
Added basic auth to salesforce execute post method

### DIFF
--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from oauthlib.oauth2 import BackendApplicationClient
 from opaque_keys.edx.keys import CourseKey
 from requests_oauthlib import OAuth2Session
+from requests.auth import HTTPBasicAuth
 
 from openedx_external_enrollments.edxapp_wrapper.get_courseware import get_course_by_id
 from openedx_external_enrollments.edxapp_wrapper.get_student import CourseEnrollment, get_user
@@ -20,6 +21,24 @@ class SalesforceEnrollment(BaseExternalEnrollment):
 
     def __str__(self):
         return "salesforce"
+
+    def _execute_post(self, url, data=None, headers=None, json_data=None):
+        """
+        Execute post request.
+        """
+        basic_auth = HTTPBasicAuth(
+            settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_USER,
+            settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_PASSWORD
+        )
+
+        response = requests.post(
+            url=url,
+            data=data,
+            headers=headers,
+            json=json_data,
+            auth=basic_auth
+        )
+        return response
 
     @staticmethod
     def _decode_utm_params(utm_params):

--- a/openedx_external_enrollments/settings/common.py
+++ b/openedx_external_enrollments/settings/common.py
@@ -61,6 +61,8 @@ def plugin_settings(settings):
     settings.SALESFORCE_API_USERNAME = "salesforce-username"
     settings.SALESFORCE_API_PASSWORD = "salesforce-password"
     settings.SALESFORCE_ENABLE_AUTHENTICATION = False
+    settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_USER= ""
+    settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_PASSWORD= ""
     settings.SALESFORCE_INSTANCE_URL =  "https://api-us-c.pgi.pearsondev.tech"
     settings.SALESFORCE_ENROLLMENT_API_PATH = "pa-edx/lead"
     settings.DROPBOX_API_ARG_DOWNLOAD = '{"path":"%s"}'

--- a/openedx_external_enrollments/settings/production.py
+++ b/openedx_external_enrollments/settings/production.py
@@ -46,6 +46,14 @@ def plugin_settings(settings):
         'SALESFORCE_ENABLE_AUTHENTICATION',
         settings.SALESFORCE_ENABLE_AUTHENTICATION
     )
+    settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_USER = getattr(settings, 'ENV_TOKENS', {}).get(
+        'SALESFORCE_ENROLLMENT_BASIC_AUTH_USER',
+        settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_USER
+    )
+    settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_PASSWORD = getattr(settings, 'ENV_TOKENS', {}).get(
+        'SALESFORCE_ENROLLMENT_BASIC_AUTH_PASSWORD',
+        settings.SALESFORCE_ENROLLMENT_BASIC_AUTH_PASSWORD
+    )
     settings.SALESFORCE_INSTANCE_URL = getattr(settings, 'ENV_TOKENS', {}).get(
         'SALESFORCE_INSTANCE_URL',
         settings.SALESFORCE_INSTANCE_URL


### PR DESCRIPTION
**Ticket**: PAE-536

Added the auth parameter to the salesforce enrollments post request and the settings to define the basic auth user and basic auth password.