### PR TITLE
Edit salesforce external enrollment to return course run key, delete …

### DIFF
--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -216,7 +216,7 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                 course_data = dict()
                 course_data["CourseName"] = salesforce_settings.get("Program_Name") or course.display_name
                 course_data["CourseID"] = "{}+{}".format(course_key.org, course_key.course)
-                course_data["CourseRunID"] = self._get_salesforce_course_id(course, course_id)
+                course_data["CourseRunID"] = course_id
                 course_data["CourseStartDate"] = self._get_course_start_date(course, line.get("user_email"), course_id)
                 course_data["CourseEndDate"] = course.end.strftime("%Y-%m-%d")
                 course_data["CourseDuration"] = "0"
@@ -226,15 +226,6 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                 courses.append(course_data)
 
         return courses
-
-    def _get_salesforce_course_id(self, course, internal_id):
-        """
-        Returns either an external course id or internal.
-        """
-        if self._is_external_course(course):
-            return course.other_course_settings.get("external_course_run_id")
-
-        return internal_id
 
     @staticmethod
     def _is_external_course(course):

--- a/openedx_external_enrollments/tests/external_enrollments/tests_salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/tests/external_enrollments/tests_salesforce_external_enrollment.py
@@ -219,11 +219,10 @@ class SalesforceEnrollmentTest(TestCase):
         self.assertEqual(expected_data, program_data)
         self.assertTrue(drupal_id.startswith(expected_drupal))
 
-    @patch.object(SalesforceEnrollment, '_get_salesforce_course_id')
     @patch.object(SalesforceEnrollment, '_get_course_start_date')
     @patch.object(SalesforceEnrollment, '_get_course_key')
     @patch.object(SalesforceEnrollment, '_get_course')
-    def test_get_courses_data(self, get_course_mock, get_course_key_mock, get_date_mock, get_salesforce_mock):
+    def test_get_courses_data(self, get_course_mock, get_course_key_mock, get_date_mock):
         """Testing _get_courses_data method."""
         self.assertEqual([], self.base._get_courses_data({}, []))  # pylint: disable=protected-access
 
@@ -242,11 +241,10 @@ class SalesforceEnrollmentTest(TestCase):
         get_course_mock.return_value = course_mock
         get_course_key_mock.return_value = CourseKey.from_string('course-v1:PX+test-course-run-id+2015')
         get_date_mock.return_value = now_date_format
-        get_salesforce_mock.return_value = 'test-salesforce'
         expected_data = {
             'CourseName': course_mock.display_name,
             'CourseID': 'PX+test-course-run-id',
-            'CourseRunID': 'test-salesforce',
+            'CourseRunID': 'test-course-id',
             'CourseStartDate': now_date_format,
             'CourseEndDate': now_date_format,
             'CourseDuration': '0',
@@ -268,25 +266,6 @@ class SalesforceEnrollmentTest(TestCase):
         get_course_mock.side_effect = Exception('test-exception')
 
         self.assertEqual([], self.base._get_courses_data({}, lines))  # pylint: disable=protected-access
-
-    @patch.object(SalesforceEnrollment, '_is_external_course')
-    def test_get_salesforce_course_id(self, external_course_mock):
-        """Testing _get_salesforce_course_id method."""
-        external_course_mock.return_value = False
-        course_mock = Mock()
-        course_mock.other_course_settings = {'external_course_run_id': 'test-settings-id'}
-
-        self.assertEqual(
-            'internal-id',
-            self.base._get_salesforce_course_id(course_mock, 'internal-id'),  # pylint: disable=protected-access
-        )
-        external_course_mock.assert_called_with(course_mock)
-
-        external_course_mock.return_value = True
-        self.assertEqual(
-            'test-settings-id',
-            self.base._get_salesforce_course_id(course_mock, 'internal-id'),  # pylint: disable=protected-access
-        )
 
     def test_is_external_course(self):
         """Testing _is_external_course method."""


### PR DESCRIPTION
…_get_salesforce_course_id method and its test

# Description:

This PR changes the SalesforceEnrollment to meet the requirement of retrieving the course run key and not the external course run key when calling _get_courses_data.

Ticket: [PAE-733](https://pearsonadvance.atlassian.net/secure/RapidBoard.jspa?rapidView=1&modal=detail&selectedIssue=PAE-733&assignee=60a6bffd9b362f0069260352)

By the way, I also thought about extending _get_salesforce_course_id by adding a new parameter in order to select either internal or external course id. With this approach, we will keep the method and its test. Although the test should be updated too. So It looks like this:
Let me know what you think?

```
def _get_salesforce_course_id(self, course, internal_id, get_external=False):
        """
        Returns the internal or external course id.

        Params:
        get_external (bool): If True, returns external course id if available. Otherwise, return internal course id.
        """
        if self._is_external_course(course) and get_external:
            return course.other_course_settings.get("external_course_run_id")

        return internal_id
```