### PR TITLE
Add logs to figure out what is happening with Salesforce

### DIFF
--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -17,6 +17,7 @@ from openedx_external_enrollments.models import ProgramSalesforceEnrollment
 
 LOG = logging.getLogger(__name__)
 
+
 class SalesforceEnrollment(BaseExternalEnrollment):
     """
     SalesforceEnrollment class.

--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -137,7 +137,7 @@ class SalesforceEnrollment(BaseExternalEnrollment):
         :param data:
         :return:
         """
-        LOG.info('Calling _get_salesforce_data for [%s] with data: %s',  self.__str__(), data)
+        LOG.info('Calling _get_salesforce_data for [%s] with data: %s', self.__str__(), data)
         salesforce_data = {}
         order_lines = data.get("supported_lines")
         if order_lines:
@@ -210,7 +210,7 @@ class SalesforceEnrollment(BaseExternalEnrollment):
         :param order_lines:
         :return:
         """
-        LOG.info('Calling _get_courses_data for [%s] with order_lines: %s',  self.__str__(), order_lines)
+        LOG.info('Calling _get_courses_data for [%s] with order_lines: %s', self.__str__(), order_lines)
         courses = []
         for line in order_lines:
             try:


### PR DESCRIPTION
# Description

This PR is intended to help us to find out what is happening with Salesforce, The problem raised when one tries to buy two courses runs from one program, and after the purchase, the SF API log did not have the program_of_interest from the program metadata, instead, it used the program_of_interest from one course. When repeating the process, `Course_Data` was an empty list, It is supposed to have the two course runs information `(CourseDuration, CourseRunID, CourseName, CourseEndDate, CourseStartDate, CourseID)`.

More information: [PAE-753](https://pearsonadvance.atlassian.net/browse/PAE-753)

I want to keep an eye on the parameters that are being passed to these `SalesforceEnrollment` methods:

_get_courses_data
_get_salesforce_data
_get_enrollment_data



