### PR TITLE
PAE-702 - Pathstream External Enrollment Integration

### DIFF
--- a/openedx_external_enrollments/external_enrollments/pathstream_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/pathstream_external_enrollment.py
@@ -1,0 +1,67 @@
+"""PathstreamExternalEnrollment class file."""
+import logging
+from datetime import datetime
+
+from django.db import IntegrityError
+
+from openedx_external_enrollments.external_enrollments.base_external_enrollment import BaseExternalEnrollment
+from openedx_external_enrollments.models import ExternalEnrollment
+
+LOG = logging.getLogger(__name__)
+
+
+class PathstreamExternalEnrollment(BaseExternalEnrollment):
+    """
+    PathstreamExternalEnrollment class.
+    """
+    def __str__(self):
+        return 'pathstream'
+
+    def _get_enrollment_data(self, data):  # pylint: disable=arguments-differ
+        """
+        Returns a string with the data required to be treated as a log.
+        String format: 'course_key,email,date_time,status'
+        """
+        return '{course_key},{email},{date_time},{status}\n'.format(
+            course_key=data.get('course_id'),
+            email=data.get('user_email'),
+            date_time=datetime.utcnow(),
+            status=str(data.get('is_active')).lower(),
+        )
+
+    def _post_enrollment(self, data, course_settings=None):
+        """
+        Save enrollment data in ExternalEnrollment model.
+        """
+        LOG.info('Calling enrollment for [%s] with data: %s', self.__str__(), data)
+        LOG.info('Calling enrollment for [%s] with course settings: %s', self.__str__(), course_settings)
+
+        try:
+            enrollment, created = ExternalEnrollment.objects.get_or_create(  # pylint: disable=no-member
+                controller_name=str(self),
+                course_shell_id=data.get('course_id'),
+                email=data.get('user_email'),
+            )
+        except IntegrityError:
+            LOG.error('Failed to complete enrollment, course_id and user_email can\'t be None')
+        else:
+            enrollment.meta = [] if created else enrollment.meta
+
+            enrollment.meta.append(
+                {
+                    'enrollment_data_formated': self._get_enrollment_data(data),
+                    'is_uploaded': False,
+                },
+            )
+            enrollment.save()
+            LOG.info(
+                'Saving External enrollment object for [%s] -- ExternalEnrollment.id = %s',
+                self.__str__(),
+                enrollment.id,
+            )
+
+    def _get_enrollment_headers(self):
+        pass
+
+    def _get_enrollment_url(self, course_settings):
+        pass

--- a/openedx_external_enrollments/factory.py
+++ b/openedx_external_enrollments/factory.py
@@ -12,6 +12,9 @@ from openedx_external_enrollments.external_enrollments.greenfig_external_enrollm
 )
 from openedx_external_enrollments.external_enrollments.icc_external_enrollment import ICCExternalEnrollment
 from openedx_external_enrollments.external_enrollments.mit_hz_external_enrollment import MITHzInstanceExternalEnrollment
+from openedx_external_enrollments.external_enrollments.pathstream_external_enrollment import (
+    PathstreamExternalEnrollment,
+)
 from openedx_external_enrollments.external_enrollments.viper_external_enrollment import ViperExternalEnrollment
 
 LOG = logging.getLogger(__name__)
@@ -37,6 +40,8 @@ class ExternalEnrollmentFactory():
             return MITHzInstanceExternalEnrollment()
         elif controller.lower() == 'viper':
             return ViperExternalEnrollment()
+        elif controller.lower() == 'pathstream':
+            return PathstreamExternalEnrollment()
         else:
             LOG.error(
                 'The external enrollment controller [%s] is not available',

--- a/openedx_external_enrollments/tests/external_enrollments/tests_pathstream_external_enrollments.py
+++ b/openedx_external_enrollments/tests/external_enrollments/tests_pathstream_external_enrollments.py
@@ -1,0 +1,170 @@
+"""Tests PathstreamExternalEnrollment class file"""
+import logging
+
+import ddt
+from django.db.utils import IntegrityError
+from django.test import TestCase
+from mock import Mock, patch
+from opaque_keys.edx.keys import CourseKey
+from testfixtures import LogCapture
+
+from openedx_external_enrollments.external_enrollments.pathstream_external_enrollment import (
+    PathstreamExternalEnrollment,
+)
+
+
+@ddt.ddt
+class PathstreamExternalEnrollmentTest(TestCase):
+    """Test class for PathstreamExternalEnrollment."""
+
+    def setUp(self):
+        """Set test instance."""
+        self.base = PathstreamExternalEnrollment()
+        self.module = 'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment'
+        self.course_id = CourseKey.from_string('course-v1:test+CS102+2019_T3')
+        self.user_email = 'test@email'
+
+    def test_str(self):
+        """
+        PathstreamExternalEnrollment overrides the __str__ method,
+        this test that the method __str__ returns the right value.
+        """
+        self.assertEqual(self.base.__str__(), 'pathstream')
+
+    @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.datetime')
+    def test_get_enrollment_data(self, datetime_mock):
+        """Testing _get_enrollment_data method."""
+        data = {
+            'user_email': self.user_email,
+            'is_active': True,
+            'course_id': self.course_id,
+        }
+        datetime_mock.utcnow.return_value = '2021-06-28 16:40:31.456900'
+        expected_data = 'course-v1:test+CS102+2019_T3,test@email,2021-06-28 16:40:31.456900,true\n'
+
+        result = self.base._get_enrollment_data(data)  # pylint: disable=protected-access
+
+        self.assertEqual(result, expected_data)
+
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.'
+        'pathstream_external_enrollment.PathstreamExternalEnrollment._get_enrollment_data'
+    )
+    def test_post_enrollment_new_enrollment(self, get_enrollment_data_mock, model_mock):
+        """This test validates _post_enrollment method for a new enrollment."""
+        data = {
+            'user_email': self.user_email,
+            'is_active': True,
+            'course_id': self.course_id,
+        }
+        enrollment_data = 'course-v1:test+CS102+2019_T3,test@email,2021-06-28 16:40:31.456900,true\n'
+        get_enrollment_data_mock.return_value = enrollment_data
+        meta_expected = [
+            {
+                'enrollment_data_formated': enrollment_data,
+                'is_uploaded': False,
+            },
+        ]
+        external_enrollment_object = Mock()
+        external_enrollment_object.id = 1
+        model_mock.objects.get_or_create.return_value = (external_enrollment_object, True)
+        log1 = 'Calling enrollment for [{}] with data: {}'.format(self.base.__str__(), data)
+        log2 = 'Calling enrollment for [{}] with course settings: {}'.format(self.base.__str__(), None)
+        log3 = 'Saving External enrollment object for [{}] -- ExternalEnrollment.id = {}'.format(
+            self.base.__str__(),
+            external_enrollment_object.id,
+        )
+
+        with LogCapture(level=logging.INFO) as log_capture:
+            self.base._post_enrollment(data)  # pylint: disable=protected-access
+
+            log_capture.check(
+                (self.module, 'INFO', log1),
+                (self.module, 'INFO', log2),
+                (self.module, 'INFO', log3),
+            )
+
+        get_enrollment_data_mock.assert_called_once_with(data)
+        model_mock.objects.get_or_create.assert_called_with(
+            controller_name='pathstream',
+            course_shell_id=self.course_id,
+            email=self.user_email,
+        )
+        external_enrollment_object.save.assert_called_once()
+        self.assertListEqual(external_enrollment_object.meta, meta_expected)
+
+    @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.'
+        'pathstream_external_enrollment.PathstreamExternalEnrollment._get_enrollment_data'
+    )
+    def test_post_enrollment_update_enrollment(self, get_enrollment_data_mock, model_mock):
+        """This test validates _post_enrollment method when an unenrollment event
+        is triggered for user and course, which have been used to create the initial
+        ExternalEnrollment object."""
+        initial_meta = [
+            {
+                'enrollment_data_formated': 'course-v1:test+CS102+2019_T3,t@email,2021-06-28 16:40:31.4569,true\n',
+                'is_uploaded': False,
+            },
+        ]
+        external_enrollment_object = Mock()
+        external_enrollment_object.meta = initial_meta
+        model_mock.objects.get_or_create.return_value = (external_enrollment_object, False)
+        data = {
+            'user_email': self.user_email,
+            'is_active': False,
+            'course_id': self.course_id,
+        }
+        unenrollment_data = 'course-v1:test+CS102+2019_T3,t@email,2021-06-29 16:50:31.456900,false\n'
+        get_enrollment_data_mock.return_value = unenrollment_data
+        meta_expected = initial_meta
+        meta_expected.append(
+            {
+                'enrollment_data_formated': unenrollment_data,
+                'is_uploaded': False,
+            },
+        )
+
+        self.base._post_enrollment(data)  # pylint: disable=protected-access
+
+        external_enrollment_object.save.assert_called_once()
+        self.assertListEqual(external_enrollment_object.meta, meta_expected)
+
+    @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.'
+        'PathstreamExternalEnrollment._get_enrollment_data')
+    @ddt.data(
+        {
+            'course_id': 1,
+            'user_email': None,
+        },
+        {
+            'course_id': None,
+            'user_email': 'test@email',
+        },
+        {},
+    )
+    def test_post_enrollment_with_missing_data(self, data, get_enrollment_mock, model_mock):
+        """This test validates the _post_enrollment execution for missing data.
+        For instance, if email or course_id are not in data, this will raise an IntegrityError as
+        email and course_id can't be None."""
+        log = 'Failed to complete enrollment, course_id and user_email can\'t be None'
+        model_mock.objects.get_or_create.side_effect = IntegrityError
+
+        with LogCapture(level=logging.ERROR) as log_capture:
+            self.base._post_enrollment(data)  # pylint: disable=protected-access
+
+            log_capture.check(
+                (self.module, 'ERROR', log),
+            )
+
+        get_enrollment_mock.assert_not_called()
+        model_mock.objects.get_or_create.assert_called_with(
+            controller_name=self.base.__str__(),
+            course_shell_id=data.get('course_id'),
+            email=data.get('user_email'),
+        )

--- a/openedx_external_enrollments/tests/tests_factory.py
+++ b/openedx_external_enrollments/tests/tests_factory.py
@@ -14,6 +14,9 @@ from openedx_external_enrollments.external_enrollments.greenfig_external_enrollm
 )
 from openedx_external_enrollments.external_enrollments.icc_external_enrollment import ICCExternalEnrollment
 from openedx_external_enrollments.external_enrollments.mit_hz_external_enrollment import MITHzInstanceExternalEnrollment
+from openedx_external_enrollments.external_enrollments.pathstream_external_enrollment import (
+    PathstreamExternalEnrollment,
+)
 from openedx_external_enrollments.external_enrollments.viper_external_enrollment import ViperExternalEnrollment
 from openedx_external_enrollments.factory import ExternalEnrollmentFactory
 
@@ -31,6 +34,7 @@ class ExternalEnrollmentFactoryTest(TestCase):
         ('greenfig', GreenfigInstanceExternalEnrollment),
         ('mit_hz', MITHzInstanceExternalEnrollment),
         ('viper', ViperExternalEnrollment),
+        ('pathstream', PathstreamExternalEnrollment),
     )
     @unpack
     def test_get_enrollment_controller(self, controller, instance, greenfig_configuration_helpers_mock,


### PR DESCRIPTION
#  Goal:
This PR is intended to integrate the basic functionality for Pathstream. And all related to the S3 file management and its task will be addressed in other PR.

# General Goal:
When a user enrolls into a Pathstream course, we want to inform them of the enrollment by writing to a file in S3 that they own. The enrollment file on S3 should be treated as an enrollment log, so a user can have multiple entries if there were multiple enrollment actions. File format: `"Open edX Course Key, Email, Date/time, Status"`.

The content is in our course, with LTI links to the Pathstream content, so we don’t use the typical redirect from the dashboard that we use for other external providers.

Ticket: [PAE-702](https://pearsonadvance.atlassian.net/browse/PAE-702)

# Solution:
Since S3 provides an SDK to handle download/update functions, `boto3` is required and the ExternalEnrollment class extends BaseExternalEnrollment but overrides _post_enrollment to use this SDK.

**This integration has two main functions:**

1.  Save the enrollment data with the File format in ExternalEnrollment.
2.  Update the remote file in S3 with the new data stored in ExternalEnrollment.

**How are these functions accomplished?:**

Every time that an external enrollment is executed (`openedx_external_enrollments.external_enrollments.execute_external_enrollment`) it will instantiate a ExternalEnrollment object and call its overridden `_post_enrollment` method.

A task will instantiate ExternalEnrollment to call its `execute_upload` method to update the file in S3 periodically.