### PR TITLE
PAE-702.2 - Pathstream S3 management Integration.

### DIFF
--- a/openedx_external_enrollments/external_enrollments/pathstream_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/pathstream_external_enrollment.py
@@ -1,7 +1,13 @@
 """PathstreamExternalEnrollment class file."""
+import base64
+import hashlib
 import logging
 from datetime import datetime
 
+import boto3
+import botocore
+from botocore.exceptions import ClientError
+from django.conf import settings
 from django.db import IntegrityError
 
 from openedx_external_enrollments.edxapp_wrapper.get_student import get_user
@@ -9,6 +15,12 @@ from openedx_external_enrollments.external_enrollments.base_external_enrollment 
 from openedx_external_enrollments.models import EnrollmentRequestLog, ExternalEnrollment
 
 LOG = logging.getLogger(__name__)
+COMPLETED = True
+UNCOMPLETED = False
+
+
+class PathstreamTaskExecutionError(Exception):
+    """Exception when the proccess of executing PathstreamExternalEnrollment.execute_upload fails."""
 
 
 class PathstreamExternalEnrollment(BaseExternalEnrollment):
@@ -17,6 +29,147 @@ class PathstreamExternalEnrollment(BaseExternalEnrollment):
     """
     def __str__(self):
         return 'pathstream'
+
+    def __init__(self):
+        self.client = None
+        self.S3_BUCKET = settings.OEE_PATHSTREAM_S3_BUCKET
+        self.S3_FILE = settings.OEE_PATHSTREAM_S3_FILE
+
+    def _init_s3(self):
+        """Define the S3 service client.
+
+        At this point, _init_s3 does not establish any AWS connection,
+        nor verify the credentials. That will happen when calling
+        _download_file or _upload_file."""
+        self.client = boto3.client(
+            's3',
+            aws_access_key_id=settings.OOE_PATHSTREAM_S3_ACCESS_KEY,
+            aws_secret_access_key=settings.OOE_PATHSTREAM_S3_SECRET_KEY,
+        )
+
+    def _download_file(self):
+        """Download the file content from an S3 Bucket.
+
+        :return: file's content (bytes)"""
+        try:
+            response = self.client.get_object(
+                Bucket=self.S3_BUCKET,
+                Key=self.S3_FILE,
+            )
+        except ClientError as error:
+            raise PathstreamTaskExecutionError(
+                '_download_file',
+                'Failed to download the content of the file from S3. Reason: {}'.format(str(error)),
+            )
+
+        LOG.info('File content [%s] was downloaded from S3 for [%s]', self.S3_FILE, self.__str__())
+
+        return response['Body'].read()
+
+    def _prepare_new_content(self, content):
+        """This method returns the new content ready to be uploaded to S3. It first sorts the input list
+        by date/time and then encode it since this is the way to upload the file content to S3.
+
+        :param: content (list of strings).
+            The elements of content are expected to be the following comma-separated format:
+            "course,email,2021-08-05 17:53:41.492901,false"
+
+        :return: bytes made up of the data passed in content.
+
+        :raise: AttributeError, IndexError or ValueError in case at least one element in content has a different
+        format than expected."""
+        try:
+            content.sort(
+                #  Extract datetime out of every element in content to be the sorting parameter.
+                key=lambda data: datetime.strptime(data.split(',')[6], settings.OOE_PATHSTREAM_S3_DATETIME_FORMAT),
+            )
+        except (AttributeError, IndexError, ValueError) as error:
+            raise PathstreamTaskExecutionError(
+                '_prepare_new_content',
+                'An enrollment data is invalid. Reason: {} \nNew data: {}'.format(str(error), content),
+            )
+
+        # Convert elements of content to bytes.
+        content = map(lambda data: data.encode(), content)
+
+        return b''.join(content)
+
+    def _upload_file(self, file_content=None):
+        """Upload the file to an S3 bucket using MD5 to ensure that data is not corrupted
+        traversing the network.
+
+        :param: file_content (bytes)."""
+        if not (isinstance(file_content, bytes) and file_content):
+            raise PathstreamTaskExecutionError(
+                '_upload_file', 'Can\'t upload a file with empty content or invalid content type.',
+            )
+
+        hash_algorithm_md5 = hashlib.md5(file_content).digest()
+        content_encoded = base64.b64encode(hash_algorithm_md5)
+
+        try:
+            response = self.client.put_object(
+                Bucket=self.S3_BUCKET,
+                Key=self.S3_FILE,
+                Body=file_content,
+                ContentMD5=content_encoded.decode(),  # String - The base64-encoded 128-bit MD5 digest of the message.
+            )
+        except ClientError as error:
+            raise PathstreamTaskExecutionError(
+                '_upload_file',
+                'Failed to upload the file to S3. Reason: {}'.format(str(error)),
+            )
+
+        LOG.info('File [%s] was uploaded to S3 for [%s], response: [%s]', self.S3_FILE, self.__str__(), response)
+
+    def execute_upload(self):
+        """
+        Context: This method will download, update and upload the S3 file content with the
+        corresponding data from new enrollments which have not been uploaded to the S3
+        file. It also updates the key flag 'is_uploaded' which is used to determine if an enrollment is already
+        uploaded to the S3 file.
+
+        :return: tuple (boolean, str). (True, 'successful-message') if the method executes properly,
+        otherwise (False, 'error-message')
+
+        True means that this method either download-update-upload the S3 file content or do not
+        proceed to download-update-upload the content because there are no new enrollments.
+        """
+        users_enrollments_qs = ExternalEnrollment.objects.filter(  # pylint: disable=no-member
+            controller_name=str(self),
+            meta__icontains='"is_uploaded":false',
+        )
+
+        if not users_enrollments_qs:
+            LOG.info('There are no new enrollments to update the S3 file.')
+            return COMPLETED, 'execute_upload completed'
+
+        new_content = []
+
+        for user_enrollments in users_enrollments_qs:
+            for enrollment in user_enrollments.meta:
+                if not enrollment.get('is_uploaded', True):
+                    new_content.append(enrollment.get('enrollment_data_formated', ''))
+
+                    enrollment['is_uploaded'] = True
+
+        self._init_s3()
+
+        if not isinstance(self.client, botocore.client.BaseClient):
+            LOG.error('_init_s3 has not been called yet or failed.')
+            return UNCOMPLETED, '_init_s3 has not been called yet or failed.'
+
+        try:
+            file_content = self._download_file()
+            file_content += self._prepare_new_content(new_content)
+
+            self._upload_file(file_content)
+        except PathstreamTaskExecutionError as error:
+            LOG.error('The proccess to update the remote S3 file has failed. Reason: %s', str(error))
+            return UNCOMPLETED, str(error)
+
+        ExternalEnrollment.objects.bulk_update(users_enrollments_qs, ['meta'])  # pylint: disable=no-member
+        return COMPLETED, 'execute_upload completed'
 
     def _get_enrollment_data(self, data):  # pylint: disable=arguments-differ
         """

--- a/openedx_external_enrollments/settings/common.py
+++ b/openedx_external_enrollments/settings/common.py
@@ -32,7 +32,7 @@ TIME_ZONE = 'UTC'
 USE_TZ = True
 
 
-def plugin_settings(settings):
+def plugin_settings(settings):  # pylint: disable=R0915
     """
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
@@ -90,3 +90,8 @@ def plugin_settings(settings):
     settings.OEE_VIPER_MUTATIONS_API_KEY = 'viper-mutations-api-key'
     settings.OEE_VIPER_API_URL = 'https://vip-demo-api.virtual-academies.com/holistic'
     settings.OEE_VIPER_IDP = 'okta'
+    settings.OEE_PATHSTREAM_S3_FILE = 'pathstream_external_enrollments.log'
+    settings.OEE_PATHSTREAM_S3_BUCKET = 'remoteloggerpathstream'
+    settings.OOE_PATHSTREAM_S3_ACCESS_KEY = 'access_key'
+    settings.OOE_PATHSTREAM_S3_SECRET_KEY = 'secret_access_key'
+    settings.OOE_PATHSTREAM_S3_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'

--- a/openedx_external_enrollments/settings/production.py
+++ b/openedx_external_enrollments/settings/production.py
@@ -150,3 +150,23 @@ def plugin_settings(settings):
         'OEE_VIPER_IDP',
         settings.OEE_VIPER_IDP,
     )
+    settings.OEE_PATHSTREAM_S3_FILE = getattr(settings, 'ENV_TOKENS', {}).get(
+        'OEE_PATHSTREAM_S3_FILE',
+        settings.OEE_PATHSTREAM_S3_FILE,
+    )
+    settings.OEE_PATHSTREAM_S3_BUCKET = getattr(settings, 'ENV_TOKENS', {}).get(
+        'OEE_PATHSTREAM_S3_BUCKET',
+        settings.OEE_PATHSTREAM_S3_BUCKET,
+    )
+    settings.OOE_PATHSTREAM_S3_ACCESS_KEY = getattr(settings, 'AUTH_TOKENS', {}).get(
+        'OOE_PATHSTREAM_S3_ACCESS_KEY',
+        settings.OOE_PATHSTREAM_S3_ACCESS_KEY,
+    )
+    settings.OOE_PATHSTREAM_S3_SECRET_KEY = getattr(settings, 'AUTH_TOKENS', {}).get(
+        'OOE_PATHSTREAM_S3_SECRET_KEY',
+        settings.OOE_PATHSTREAM_S3_SECRET_KEY,
+    )
+    settings.OOE_PATHSTREAM_S3_DATETIME_FORMAT = getattr(settings, 'ENV_TOKENS', {}).get(
+        'OOE_PATHSTREAM_S3_DATETIME_FORMAT',
+        settings.OOE_PATHSTREAM_S3_DATETIME_FORMAT,
+    )

--- a/openedx_external_enrollments/settings/test.py
+++ b/openedx_external_enrollments/settings/test.py
@@ -67,3 +67,9 @@ ICC_AUTH_METHOD = "test-auth-method"
 OEE_VIPER_IDP = 'okta'
 OEE_VIPER_MUTATIONS_API_KEY = 'viper-mutations-api-key'
 OEE_VIPER_API_URL = 'https://viper-api-url'
+
+OEE_PATHSTREAM_S3_FILE = 'test.log'
+OEE_PATHSTREAM_S3_BUCKET = 'test'
+OOE_PATHSTREAM_S3_ACCESS_KEY = 'access_key'
+OOE_PATHSTREAM_S3_SECRET_KEY = 'secret_access_key'
+OOE_PATHSTREAM_S3_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'

--- a/openedx_external_enrollments/tests/external_enrollments/tests_pathstream_external_enrollments.py
+++ b/openedx_external_enrollments/tests/external_enrollments/tests_pathstream_external_enrollments.py
@@ -1,15 +1,20 @@
 """Tests PathstreamExternalEnrollment class file"""
+import io
 import logging
 
+import boto3
+import botocore
 import ddt
+from botocore.exceptions import ClientError
 from django.db.utils import IntegrityError
 from django.test import TestCase
-from mock import Mock, patch
+from mock import MagicMock, Mock, call, patch
 from opaque_keys.edx.keys import CourseKey
 from testfixtures import LogCapture
 
 from openedx_external_enrollments.external_enrollments.pathstream_external_enrollment import (
     PathstreamExternalEnrollment,
+    PathstreamTaskExecutionError,
 )
 
 
@@ -30,6 +35,439 @@ class PathstreamExternalEnrollmentTest(TestCase):
         this test that the method __str__ returns the right value.
         """
         self.assertEqual(self.base.__str__(), 'pathstream')
+
+    @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.boto3', spec=boto3)
+    def test_init_s3_all_settings_setup(self, boto3_mock):
+        """
+        _init_s3 must be called with all parameters
+        """
+        access_key_id = 'access_key'
+        secret_access_key = 'secret_access_key'
+        boto3_mock.client.return_value = Mock(spec=botocore.client.BaseClient)
+
+        self.base._init_s3()  # pylint: disable=protected-access
+
+        boto3_mock.client.assert_called_with(
+            's3',
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
+        self.assertIsInstance(self.base.client, botocore.client.BaseClient)
+
+    def test_download_file(self):
+        """
+        _download_file must return the downloaded content from the S3 file if called with all parameters and the
+        s3 connection is established.
+        """
+        s3_file = 'test.log'
+        s3_bucket = 'test'
+        expected_file_content = 'file_content_test'
+        self.base.client = Mock(spec=boto3.client('s3'))
+        self.base.client.get_object.return_value = {
+            'Body': io.StringIO(expected_file_content),
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+            },
+        }
+        log = 'File content [{}] was downloaded from S3 for [{}]'.format(s3_file, self.base.__str__())
+
+        with LogCapture(level=logging.INFO) as log_capture:
+            file_content = self.base._download_file()  # pylint: disable=protected-access
+
+            log_capture.check(
+                (self.module, 'INFO', log),
+            )
+
+        self.base.client.get_object.assert_called_with(
+            Bucket=s3_bucket,
+            Key=s3_file,
+        )
+        self.assertEqual(file_content, expected_file_content)
+
+    def test_download_file_error(self):
+        """If no connection, credentials or wrong parameter values
+        _download_file should handle ClientError and raise PathstreamTaskExecutionError."""
+        code = '400'
+        message = 'Failed'
+        operation = 'get_object'
+        clienterror_msg = 'An error occurred ({}) when calling the {} operation: {}'.format(
+            code,
+            operation,
+            message,
+        )
+        self.base.client = Mock(spec=boto3.client('s3'))
+        self.base.client.get_object.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': code,
+                    'Message': message,
+                },
+            },
+            operation,
+        )
+
+        with self.assertRaisesMessage(PathstreamTaskExecutionError, clienterror_msg):
+            self.base._download_file()  # pylint: disable=protected-access
+
+    def test_prepare_new_content(self):
+        """This test validates that _prepare_new_content accomplish
+        its task of sorting and encoding."""
+        enrollment_data_1 = 'course_T1,username,fullname,fname,lname,1@mail,2021-06-29 16:50:00.456900,true\n'
+        enrollment_data_2 = 'course_T2,username,fullname,fname,lname,2@mail,2021-06-29 16:51:00.456900,true\n'
+        enrollment_data_3 = 'course_T2,username,fullname,fname,lname,2@mail,2021-06-29 16:52:00.456900,false\n'
+        enrollment_data_4 = 'course_T1,username,fullname,fname,lname,1@mail,2021-06-29 16:53:00.456900,false\n'
+        content = [
+            enrollment_data_1,
+            enrollment_data_4,
+            enrollment_data_2,
+            enrollment_data_3,
+        ]
+        expected_result = (
+            enrollment_data_1.encode() +
+            enrollment_data_2.encode() +
+            enrollment_data_3.encode() +
+            enrollment_data_4.encode()
+        )
+
+        result = self.base._prepare_new_content(content)  # pylint: disable=protected-access
+
+        self.assertEqual(result, expected_result)
+
+    def test_prepare_new_content_error(self):
+        """This test validates that _prepare_new_content raises
+        PathstreamTaskExecutionError when called with invalid data.
+        The 'content' variable will raise an Index error, after applying
+        the split function to it and accessing to a non existing index."""
+        content = [
+            'course_T1,username,fullname,fname,lname,1@mail,2021-06-29 16:53:00.456900,false\n',
+            'invalid_data\n',
+        ]
+        error_tuple = (
+            '_prepare_new_content',
+            'An enrollment data is invalid. Reason: {} \nNew data: {}'.format('list index out of range', content),
+        )
+
+        with self.assertRaisesMessage(PathstreamTaskExecutionError, str(error_tuple)):
+            self.base._prepare_new_content(content)  # pylint: disable=protected-access
+
+    @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.base64')
+    @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.hashlib')
+    def test_upload_file(self, mock_hash, mock_base64):
+        """This test validates that _upload file calls the method to update
+        the S3 file with the right parameters."""
+        s3_file = 'test.log'
+        s3_bucket = 'test'
+        self.base.client = Mock(spec=boto3.client('s3'))
+        response = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+            },
+        }
+        self.base.client.put_object.return_value = response
+        content = b'content'
+        content_md5 = 'mgNkuembtIDdJeHwKEyFVQ=='
+        hash_md5 = b'\x9a\x03d\xb9\xe9\x9b\xb4\x80\xdd%\xe1\xf0(L\x85U'
+        mock_hash.md5.return_value.digest.return_value = hash_md5
+        mock_base64.b64encode.return_value.decode.return_value = content_md5
+        log = 'File [{}] was uploaded to S3 for [{}], response: [{}]'.format(s3_file, self.base.__str__(), response)
+
+        with LogCapture(level=logging.INFO) as log_capture:
+            self.base._upload_file(content)  # pylint: disable=protected-access
+
+            log_capture.check(
+                (self.module, 'INFO', log),
+            )
+
+        self.base.client.put_object.assert_called_once_with(
+            Bucket=s3_bucket,
+            Key=s3_file,
+            Body=content,
+            ContentMD5=content_md5,
+        )
+        mock_hash.md5.assert_called_once_with(content)
+        mock_hash.md5().digest.assert_called_once()
+        mock_base64.b64encode.assert_called_once_with(hash_md5)
+
+    @ddt.data(None, b'', 'string', [], {})
+    def test_upload_file_with_wrong_file_content(self, content):
+        """When _upload_file is called without the content parameter or its value
+        is empty, it must raise an PathstreamTaskExecutionError."""
+        self.base.client = Mock(spec=boto3.client('s3'))
+        error_tuple = ('_upload_file', 'Can\'t upload a file with empty content or invalid content type.')
+
+        with self.assertRaisesMessage(PathstreamTaskExecutionError, str(error_tuple)):
+            self.base._upload_file(content)  # pylint: disable=protected-access
+
+        self.base.client.put_object.assert_not_called()
+
+    def test_upload_file_error(self):
+        """When connection is forbidden or conection can not be
+        established, the boto3.client('s3').put_object will raise
+        a ClientError and _upload_file must also raise PathstreamTaskExecutionError.
+        """
+        code = '400'
+        message = 'Failed'
+        operation = 'put_object'
+        clienterror_msg = 'An error occurred ({}) when calling the {} operation: {}'.format(
+            code,
+            operation,
+            message,
+        )
+        self.base.client = Mock(spec=boto3.client('s3'))
+        self.base.client.put_object.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': code,
+                    'Message': message,
+                },
+            },
+            operation,
+        )
+
+        with self.assertRaisesMessage(PathstreamTaskExecutionError, clienterror_msg):
+            self.base._upload_file(b'content')  # pylint: disable=protected-access
+
+    @patch.object(PathstreamExternalEnrollment, '_init_s3')
+    @patch.object(PathstreamExternalEnrollment, '_download_file')
+    @patch.object(PathstreamExternalEnrollment, '_prepare_new_content')
+    @patch.object(PathstreamExternalEnrollment, '_upload_file')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment',
+        )
+    def test_successful_execute_upload_with_data(
+            self, model_mock, upload_mock, prepare_mock, download_mock, init_s3_mock):
+        """Testing _execute_upload with data and a successfull proccess of
+        downloading, updating, uploading.
+
+        'is_uploaded' value must change from False to True.
+        """
+        self.base.client = Mock(spec=boto3.client('s3'))
+        enrollment_data1 = 'course1,email,username,fullname,fname,lname,2021-07-09 16:53:41.492901,true\n'
+        enrollment_data2 = 'course1,email,username,fullname,fname,lname,2021-07-20 16:53:41.492901,false\n'
+        enrollment_data3 = 'course1,email,username,fullname,fname,lname,2021-07-01 16:53:41.492901,true\n'
+        enrollment_data4 = 'course1,email,username,fullname,fname,lname,2021-07-10 16:53:41.492901,false\n'
+        qs = [
+            Mock(
+                controller_name='pathstream',
+                email='test1@gmail.com',
+                meta=[
+                    {
+                        'is_uploaded': False,
+                        'enrollment_data_formated': enrollment_data1,
+                    },
+                    {
+                        'is_uploaded': False,
+                        'enrollment_data_formated': enrollment_data2,
+                    },
+                ],
+            ),
+            Mock(
+                controller_name='pathstream',
+                email='test2@gmail.com',
+                meta=[
+                    {
+                        'is_uploaded': True,
+                        'enrollment_data_formated': enrollment_data3,
+                    },
+                    {
+                        'is_uploaded': False,
+                        'enrollment_data_formated': enrollment_data4,
+                    },
+                ],
+            ),
+        ]
+        model_mock.objects.filter.return_value = qs
+        file_content = b'course,email,username,fullname,fname,lname,2021-07-08 10:50:41.492901,true\n'
+        download_mock.return_value = file_content
+        new_content = enrollment_data1.encode() + enrollment_data4.encode() + enrollment_data2.encode()
+        prepare_mock.return_value = new_content
+        new_file_content = file_content + new_content
+
+        result = self.base.execute_upload()
+
+        model_mock.objects.filter.assert_called_with(
+            controller_name='pathstream',
+            meta__icontains='"is_uploaded":false',
+        )
+        init_s3_mock.assert_called_once()
+        download_mock.assert_called_once()
+        prepare_mock.assert_called_once_with(
+            [
+                enrollment_data1,
+                enrollment_data2,
+                enrollment_data4,
+            ],
+        )
+        upload_mock.assert_called_once_with(new_file_content)
+        model_mock.objects.bulk_update.assert_called_with(qs, ['meta'])
+        self.assertEqual(qs[0].meta[0]['is_uploaded'], True)
+        self.assertEqual(qs[0].meta[1]['is_uploaded'], True)
+        self.assertEqual(qs[1].meta[1]['is_uploaded'], True)
+        self.assertEqual(result[0], True)
+        self.assertEqual(result[1], 'execute_upload completed')
+
+    @patch.object(PathstreamExternalEnrollment, '_init_s3')
+    @patch.object(PathstreamExternalEnrollment, '_download_file')
+    @patch.object(PathstreamExternalEnrollment, '_prepare_new_content')
+    @patch.object(PathstreamExternalEnrollment, '_upload_file')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment',
+        )
+    def test_successful_execute_upload_without_data(
+            self, model_mock, upload_mock, prepare_mock, download_mock, init_s3_mock):
+        """Testing _execute_upload without data, In this case the method
+        must not call any other method.
+
+        Does not have to update any ExternalEnrollment meta
+        """
+        model_mock.objects.filter.return_value = []
+        log = 'There are no new enrollments to update the S3 file.'
+
+        with LogCapture(level=logging.INFO) as log_capture:
+            result = self.base.execute_upload()
+
+            log_capture.check(
+                (self.module, 'INFO', log),
+            )
+
+        init_s3_mock.assert_not_called()
+        download_mock.assert_not_called()
+        prepare_mock.assert_not_called()
+        upload_mock.assert_not_called()
+        model_mock.objects.bulk_update.assert_not_called()
+        self.assertEqual(result[0], True)
+        self.assertEqual(result[1], 'execute_upload completed')
+
+    @patch.object(PathstreamExternalEnrollment, '_init_s3')
+    @patch.object(PathstreamExternalEnrollment, '_download_file')
+    @patch.object(PathstreamExternalEnrollment, '_prepare_new_content')
+    @patch.object(PathstreamExternalEnrollment, '_upload_file')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment',
+        )
+    def test_failed_execute_upload(self, model_mock, upload_mock, prepare_mock, download_mock, init_s3_mock):
+        """When any of the methods related to S3 file management fails, it must raise an PathstreamTaskExecutionError
+        which should be capture by _execute_upload in order to log the error."""
+        self.base.client = Mock(spec=boto3.client('s3'))
+        model_mock.objects.filter.return_value = [
+            Mock(
+                controller_name='pathstream',
+                email='test1@gmail.com',
+                meta=[
+                    {
+                        'is_uploaded': False,
+                        'enrollment_data_formated': 'course,email,uname,fullname,,,2021-07-09 16:53:41.492901,true\n',
+                    },
+                ],
+            ),
+        ]
+        error_operation_msg = ('_download_file', 'error.')
+        log = 'The proccess to update the remote S3 file has failed. Reason: ' + str(error_operation_msg)
+        download_mock.side_effect = PathstreamTaskExecutionError(error_operation_msg[0], error_operation_msg[1])
+
+        with LogCapture(level=logging.ERROR) as log_capture:
+            result = self.base.execute_upload()
+
+            log_capture.check(
+                (self.module, 'ERROR', log),
+            )
+
+        init_s3_mock.assert_called()
+        prepare_mock.assert_not_called()
+        upload_mock.assert_not_called()
+        model_mock.objects.bulk_update.assert_not_called()
+        self.assertEqual(result[0], False)
+        self.assertEqual(result[1], str(error_operation_msg))
+
+    @patch.object(PathstreamExternalEnrollment, '_init_s3')
+    @patch.object(PathstreamExternalEnrollment, '_download_file')
+    @patch.object(PathstreamExternalEnrollment, '_prepare_new_content')
+    @patch.object(PathstreamExternalEnrollment, '_upload_file')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment',
+        )
+    def test_execute_upload_init_s3_failed(
+            self, model_mock, upload_mock, prepare_mock, download_mock, init_s3_mock):
+        """This test checks that if _init_s3 is called but it does not define self.client as a BaseClient instance,
+        then execute_upload must log an error and return the tuple (False, "error_message")."""
+        model_mock.objects.filter.return_value = [
+            Mock(
+                controller_name='pathstream',
+                email='test1@gmail.com',
+                meta=[
+                    {
+                        'is_uploaded': False,
+                        'enrollment_data_formated': 'course,email,uname,fullname,,,2021-07-09 16:53:41.492901,true\n',
+                    },
+                ],
+            ),
+        ]
+        log = '_init_s3 has not been called yet or failed.'
+
+        with LogCapture(level=logging.ERROR) as log_capture:
+            result = self.base.execute_upload()
+
+            log_capture.check(
+                (self.module, 'ERROR', log),
+            )
+
+        init_s3_mock.assert_called()
+        self.assertEqual(result[0], False)
+        self.assertEqual(result[1], log)
+        prepare_mock.assert_not_called()
+        upload_mock.assert_not_called()
+        download_mock.assert_not_called()
+        model_mock.objects.bulk_update.assert_not_called()
+
+    @patch.object(PathstreamExternalEnrollment, '_init_s3')
+    @patch.object(PathstreamExternalEnrollment, '_download_file')
+    @patch.object(PathstreamExternalEnrollment, '_prepare_new_content')
+    @patch.object(PathstreamExternalEnrollment, '_upload_file')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.ExternalEnrollment',
+        )
+    def test_execute_upload_calling_methods_in_order(
+            self, model_mock, upload_mock, prepare_mock, download_mock, init_s3_mock):
+        """This test validates that execute_upload calls the following methods strictly in this order:
+            1. _init_s3
+            2. _download_file
+            3. _prepare_new_content
+            4. _upload_file
+            5. ExternalEnrollment.objects.bulk_update
+        """
+        self.base.client = Mock(spec=boto3.client('s3'))
+        file_content = b'filecontent\n'
+        new_content = b'course1,email,uname,fullname,,,2021-07-09 16:53:41.492901,true\n'
+        download_mock.return_value = file_content
+        prepare_mock.return_value = new_content
+        parent_mock = MagicMock()  # Used to record calls.
+        parent_mock.attach_mock(init_s3_mock, 'init_s3_mock')
+        parent_mock.attach_mock(download_mock, 'download_mock')
+        parent_mock.attach_mock(prepare_mock, 'prepare_mock')
+        parent_mock.attach_mock(upload_mock, 'upload_mock')
+        parent_mock.attach_mock(model_mock.objects.bulk_update, 'bulk_update')
+        record = Mock(
+            controller_name='pathstream',
+            email='test1@gmail.com',
+            meta=[
+                {
+                    'is_uploaded': False,
+                    'enrollment_data_formated': 'course1,email,uname,fullname,,,2021-07-09 16:53:41.492901,true\n',
+                },
+            ],
+        )
+        model_mock.objects.filter.return_value = [record]
+        expected_order_calls = [
+            call.init_s3_mock(),
+            call.download_mock(),
+            call.prepare_mock(['course1,email,uname,fullname,,,2021-07-09 16:53:41.492901,true\n']),
+            call.upload_mock(file_content + new_content),
+            call.bulk_update([record], ['meta']),
+        ]
+
+        self.base.execute_upload()
+
+        self.assertEqual(parent_mock.mock_calls, expected_order_calls)
 
     @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.get_user')
     @patch('openedx_external_enrollments.external_enrollments.pathstream_external_enrollment.datetime')
@@ -69,7 +507,7 @@ class PathstreamExternalEnrollmentTest(TestCase):
             'is_active': True,
             'course_id': self.course_id,
         }
-        enrollment_data = 'course-v1:test+CS102+2019_T3,test@email,,,2021-06-28 16:40:31.456900,true\n'
+        enrollment_data = 'course,test@email,uname,fullname,,,2021-06-28 16:40:31.456900,true\n'
         get_enrollment_data_mock.return_value = enrollment_data
         meta_expected = [
             {
@@ -120,7 +558,7 @@ class PathstreamExternalEnrollmentTest(TestCase):
         ExternalEnrollment object."""
         initial_meta = [
             {
-                'enrollment_data_formated': 'course-v1:test+CS102+2019_T3,t@email,2021-06-28 16:40:31.4569,true\n',
+                'enrollment_data_formated': 'course,t@email,uname,fullname,,,2021-06-28 16:40:31.4569,true\n',
                 'is_uploaded': False,
             },
         ]
@@ -132,7 +570,7 @@ class PathstreamExternalEnrollmentTest(TestCase):
             'is_active': False,
             'course_id': self.course_id,
         }
-        unenrollment_data = 'course-v1:test+CS102+2019_T3,t@email,2021-06-29 16:50:31.456900,false\n'
+        unenrollment_data = 'course,t@email,uname,fullname,,,2021-06-29 16:50:31.456900,false\n'
         get_enrollment_data_mock.return_value = unenrollment_data
         meta_expected = initial_meta
         meta_expected.append(

--- a/openedx_external_enrollments/tests/tests_tasks.py
+++ b/openedx_external_enrollments/tests/tests_tasks.py
@@ -3,7 +3,10 @@ import unittest
 
 from mock import patch
 
-from openedx_external_enrollments.tasks import refresh_viper_api_keys
+from openedx_external_enrollments.external_enrollments.pathstream_external_enrollment import (
+    PathstreamTaskExecutionError,
+)
+from openedx_external_enrollments.tasks import refresh_viper_api_keys, run_pathstream_task
 
 
 class TestViperTasks(unittest.TestCase):
@@ -48,3 +51,46 @@ class TestViperTasks(unittest.TestCase):
 
         refresh_api_keys_mock.assert_called_once()
         refresh_viper_api_keys_task_retry_mock.assert_called_once()
+
+
+class TestPathstreamTask(unittest.TestCase):
+    """Test class for Pathstream tasks."""
+
+    @patch('openedx_external_enrollments.tasks.run_pathstream_task.retry')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment'
+        '.PathstreamExternalEnrollment.execute_upload'
+    )
+    def test_run_pathstream_task_completed(self, execute_upload_mock, run_pathstream_task_retry_mock):
+        """
+        This test checks the execution of run_pathstream_task when PathstreamExternalEnrollment.execute_upload
+        returns a successful response.
+        """
+        execute_upload_mock.return_value = True, 'execute_upload completed'
+        expected_result = {'message': 'execute_upload completed'}
+
+        result = run_pathstream_task()  # pylint: disable=no-value-for-parameter
+
+        execute_upload_mock.assert_called_once()
+        run_pathstream_task_retry_mock.assert_not_called()
+        self.assertEqual(result, expected_result)
+
+    @patch('openedx_external_enrollments.tasks.run_pathstream_task.retry')
+    @patch(
+        'openedx_external_enrollments.external_enrollments.pathstream_external_enrollment'
+        '.PathstreamExternalEnrollment.execute_upload'
+    )
+    def test_run_pathstream_task_not_completed(self, execute_upload_mock, mock_retry):
+        """
+        This test checks the execution of run_pathstream_task when PathstreamExternalEnrollment.execute_upload
+        returns a failed response. Therefore, this test validates that PathstreamTaskExecutionError is raised.
+        """
+        error_msg = 'test-ExecutionError-message'
+        execute_upload_mock.return_value = False, error_msg
+        mock_retry.return_value = PathstreamTaskExecutionError(error_msg)
+
+        with self.assertRaises(PathstreamTaskExecutionError):
+            run_pathstream_task()  # pylint: disable=no-value-for-parameter
+
+        execute_upload_mock.assert_called_once()
+        mock_retry.assert_called_once()


### PR DESCRIPTION
#  Goal:
This PR is based on [Basic Pathstream Integration](https://github.com/Pearson-Advance/openedx-external-enrollments/pull/38/)  and is intended to integrate the S3 file management functionality for Pathstream as well as to enable a task to perform the operation to update the remote S3 file.

The idea is that the task will be executed by an API --which is out of the scope of this PR--, this task will conduct a download-update-upload process in order to upload new data to the remote S3 file. Since Basic Pathstream Integration, the data is being persisted in a list of dictionaries in ExternalEnrollment.meta ---let me show you an example with the following snippet of code--, every dictionary has an 'is_uploaded' key which will be usefull to identify the data which is able to be uploaded.

```
[
     {
         'is_uploaded': True,
         'enrollment_data_formated': 'test_data_3',  # This was already uploaded
     },
     {
         'is_uploaded': False,
         'enrollment_data_formated': 'test_data_4', # Pending to be uploaded
     },
]
```
**To Keep in mind:**
Since S3 provides an SDK to handle download/upload functions, `boto3` is required and the ExternalEnrollment class extends BaseExternalEnrollment but overrides _post_enrollment to use this SDK.

# General Goal:
When a user enrolls into a Pathstream course, we want to inform them of the enrollment by writing to a file in S3 that they own. The enrollment file on S3 should be treated as an enrollment log, so a user can have multiple entries if there were multiple enrollment actions. File format: `"Open edX Course Key, Email, Date/time, Status"`.

The content is in our course, with LTI links to the Pathstream content, so we don’t use the typical redirect from the dashboard that we use for other external providers.

Ticket: [PAE-702](https://pearsonadvance.atlassian.net/browse/PAE-702)