### PR TITLE
PAE-702.4 - Fix upgrade dependencies, add boto3 and botocore.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,3 +10,5 @@ oauthlib
 requests-oauthlib
 requests
 xmltodict
+boto3==1.4.8
+botocore==1.8.17

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,23 +7,29 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
+boto3==1.4.8              # via -c requirements/constraints.txt, -r requirements/base.in
+botocore==1.8.17          # via -c requirements/constraints.txt, -r requirements/base.in, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-django==2.2.20            # via -c requirements/constraints.txt, -r requirements/base.in, jsonfield2
+certifi==2021.5.30        # via requests
+chardet==3.0.4            # via requests
+django==2.2.24            # via -c requirements/constraints.txt, -r requirements/base.in, jsonfield2
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in
+docutils==0.17.1          # via botocore
 edx-opaque-keys==2.1.0    # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.10                # via requests
+jmespath==0.10.0          # via boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==3.0.37             # via celery
 oauthlib==3.0.1           # via -c requirements/constraints.txt, -r requirements/base.in, requests-oauthlib
-pbr==5.5.1                # via stevedore
-pymongo==3.11.3           # via edx-opaque-keys
+pbr==5.6.0                # via stevedore
+pymongo==3.12.0           # via edx-opaque-keys
+python-dateutil==2.8.2    # via botocore
 pytz==2021.1              # via celery, django
 requests-oauthlib==1.3.0  # via -r requirements/base.in
-requests==2.25.1          # via -r requirements/base.in, requests-oauthlib
-six==1.15.0               # via edx-opaque-keys, stevedore
+requests==2.23.0          # via -c requirements/constraints.txt, -r requirements/base.in, requests-oauthlib
+s3transfer==0.1.13        # via boto3
+six==1.16.0               # via edx-opaque-keys, python-dateutil, stevedore
 sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via -c requirements/constraints.txt, edx-opaque-keys
-urllib3==1.26.4           # via requests
+urllib3==1.25.11          # via requests
 xmltodict==0.12.0         # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,6 +25,9 @@ oauthlib==3.0.1
 pip-tools<5.0.0
 edx-opaque-keys==2.1.0
 astroid==2.3.3
+boto3==1.4.8
+botocore==1.8.17
+requests==2.23.0
 
 # 5.0.0 dropped support for Python 3.5
 isort<5.0.0
@@ -39,3 +42,13 @@ stevedore<2.0.0
 # Quality constraints:
 pylint==2.4.2
 
+# Pip-tools constraints:
+# click version 8.0.0 drops support for python 3.5
+click==7.1.2
+
+# Tox constraints:
+tox==3.15.0
+packaging==20.3
+platformdirs==2.0.2
+zipp==1.0.0
+importlib-resources==1.5.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,6 @@
 #
 #    pip-compile --output-file=requirements/pip-tools.txt requirements/pip-tools.in
 #
-click==7.1.2              # via pip-tools
+click==7.1.2              # via -c requirements/constraints.txt, pip-tools
 pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+six==1.16.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -10,5 +10,6 @@ lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.7.0        # via -r requirements/quality.in
 pylint==2.4.2             # via -c requirements/constraints.txt, -r requirements/quality.in
-six==1.15.0               # via astroid
+six==1.16.0               # via astroid
+typed-ast==1.4.3          # via astroid
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,27 +7,33 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
+boto3==1.4.8              # via -c requirements/constraints.txt, -r requirements/base.txt
+botocore==1.8.17          # via -c requirements/constraints.txt, -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt
-certifi==2020.12.5        # via -r requirements/base.txt, requests
-chardet==4.0.0            # via -r requirements/base.txt, requests
+certifi==2021.5.30        # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
 coverage==5.5             # via -r requirements/test.in
 ddt==1.4.2                # via -r requirements/test.in
-django==2.2.20            # via -c requirements/constraints.txt, -r requirements/base.txt, jsonfield2
+django==2.2.24            # via -c requirements/constraints.txt, -r requirements/base.txt, jsonfield2
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt
+docutils==0.17.1          # via -r requirements/base.txt, botocore
 edx-opaque-keys==2.1.0    # via -c requirements/constraints.txt, -r requirements/base.txt
 idna==2.10                # via -r requirements/base.txt, requests
+jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt
 kombu==3.0.37             # via -r requirements/base.txt, celery
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 oauthlib==3.0.1           # via -c requirements/constraints.txt, -r requirements/base.txt, requests-oauthlib
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
+pbr==5.6.0                # via -r requirements/base.txt, stevedore
+pymongo==3.12.0           # via -r requirements/base.txt, edx-opaque-keys
+python-dateutil==2.8.2    # via -r requirements/base.txt, botocore
 pytz==2021.1              # via -r requirements/base.txt, celery, django
 requests-oauthlib==1.3.0  # via -r requirements/base.txt
-requests==2.25.1          # via -r requirements/base.txt, requests-oauthlib
-six==1.15.0               # via -r requirements/base.txt, edx-opaque-keys, mock, stevedore
+requests==2.23.0          # via -c requirements/constraints.txt, -r requirements/base.txt, requests-oauthlib
+s3transfer==0.1.13        # via -r requirements/base.txt, boto3
+six==1.16.0               # via -r requirements/base.txt, edx-opaque-keys, mock, python-dateutil, stevedore
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-opaque-keys
-testfixtures==6.17.1      # via -r requirements/test.in
-urllib3==1.26.4           # via -r requirements/base.txt, requests
+testfixtures==6.18.1      # via -r requirements/test.in
+urllib3==1.25.11          # via -r requirements/base.txt, requests
 xmltodict==0.12.0         # via -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,14 +4,19 @@
 #
 #    pip-compile --output-file=requirements/tox.txt requirements/tox.in
 #
-appdirs==1.4.4            # via virtualenv
-distlib==0.3.1            # via virtualenv
+backports.entry-points-selectable==1.1.0  # via virtualenv
+distlib==0.3.2            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-packaging==20.9           # via tox
+importlib-metadata==1.7.0  # via backports.entry-points-selectable, importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via -c requirements/constraints.txt, virtualenv
+more-itertools==8.9.0     # via zipp
+packaging==20.3           # via -c requirements/constraints.txt, tox
+platformdirs==2.0.2       # via -c requirements/constraints.txt, virtualenv
 pluggy==0.13.1            # via tox
 py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
+six==1.16.0               # via packaging, tox, virtualenv
 toml==0.10.2              # via tox
-tox==3.23.0               # via -r requirements/tox.in
-virtualenv==20.4.3        # via tox
+tox==3.15.0               # via -c requirements/constraints.txt, -r requirements/tox.in
+virtualenv==20.7.2        # via tox
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
# Description:
This PR is intended to fix some dependencies in order to work with python 3.5 as well as to be consistent with the dependencies on the platform. Some context: when adding boto3 and botocore for the Pathstream Integration, It was necessary to run `$ make upgrade` , then the latest versions of the dependencies started to be downloaded but some of them were no longer compatible with python 3.5 and different to the ones on the platform.

