### PR TITLE
PAE-702.5 - Fix: Add *args and **kwargs parameters to Pathstream task function.

### DIFF
--- a/openedx_external_enrollments/tasks.py
+++ b/openedx_external_enrollments/tasks.py
@@ -41,7 +41,7 @@ def refresh_viper_api_keys(self, *args, **kwargs):  # pylint: disable=unused-arg
 
 
 @task(bind=True, default_retry_delay=5*60)  # pylint: disable=not-callable
-def run_pathstream_task(self):
+def run_pathstream_task(self, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Executes the _execute_upload method of the Pathstream controller in order to update the remote
     S3 file.


### PR DESCRIPTION
## Description:

The API which executes the tasks in Openedx_external_enrollments passes **kwargs arguments to the task
([Check it out here.](https://github.com/Pearson-Advance/pearson-core/blob/57399ae0a3a076ecada4fae38bd5a46165fe2ff6/pearson_core/api/v1/views.py#L455)). The current Pathstream task raises an error since it gets an unexpected keyword argument 'task_name', therefore this PR fixes it.