### PR TITLE
PAE 702.6 - Handle duplicated data.

### DIFF
--- a/openedx_external_enrollments/tests/external_enrollments/tests_pathstream_external_enrollments.py
+++ b/openedx_external_enrollments/tests/external_enrollments/tests_pathstream_external_enrollments.py
@@ -692,6 +692,9 @@ class PathstreamExternalEnrollmentTest(TestCase):
         )
         new_enrollment_data = 'course1,email,username,fullname,,,2021-07-21 16:53:42.492901,true\n'
 
-        result = self.base._is_enrollment_duplicated(user_enrollments.meta, new_enrollment_data)
+        result = self.base._is_enrollment_duplicated(  # pylint: disable=protected-access
+            user_enrollments.meta,
+            new_enrollment_data
+        )
 
         self.assertEqual(result, False)


### PR DESCRIPTION
## Description:
This PR is intended to fix duplicated data due to the current behavior of the unenrollment events. When users are unenrolled trough the instructor dashboard (bulk unenrollment), the unenrollment signal is triggered twice for openedx_external_enrollments, which means it is called twice with the same data.

This PR focuses on Pathstream but this behaviour impacts all the integrations.