### PR TITLE
PAE-830 - Update Greenfig integration.

### DIFF
--- a/openedx_external_enrollments/external_enrollments/greenfig_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/greenfig_external_enrollment.py
@@ -54,10 +54,12 @@ class GreenfigInstanceExternalEnrollment(BaseExternalEnrollment):
         }
 
     def _get_enrollment_data(self, data, course_settings):
-        """Returns a file in memory with a new or updated enroll."""
+        """Returns a tuple made up of a file in memory with a new or updated enroll, and the enrollment data.
+
+        :return: (file, string)"""
         user, _ = get_user(email=data.get('user_email'))
         dropbox_file = self._get_course_list(course_settings).text
-        enrollment_data = u'{date}, {fullname}, {first_name}, {last_name}, {email}, {course_id}, {enrolled}\n'.format(
+        enrollment_data = '{date}, {fullname}, {first_name}, {last_name}, {email}, {course_id}, {enrolled}\n'.format(
             date=datetime.now().strftime(settings.DROPBOX_DATE_FORMAT),
             fullname=user.profile.name,
             first_name=user.first_name,
@@ -71,7 +73,7 @@ class GreenfigInstanceExternalEnrollment(BaseExternalEnrollment):
         temp_file.write(dropbox_file)
         temp_file.seek(0)
 
-        return temp_file.getvalue()
+        return temp_file.getvalue(), enrollment_data
 
     def _get_enrollment_url(self, course_settings):
         """Gets dropbox upload file url."""
@@ -104,12 +106,12 @@ class GreenfigInstanceExternalEnrollment(BaseExternalEnrollment):
         Get request data and execute the post request.
         """
         url = self._get_enrollment_url(course_settings)
-        json_data = self._get_enrollment_data(data, course_settings)
+        json_data, enrollment_data = self._get_enrollment_data(data, course_settings)
         LOG.info('calling enrollment for [%s] with data: %s', self.__str__(), json_data)
         LOG.info('calling enrollment for [%s] with url: %s', self.__str__(), url)
         LOG.info('calling enrollment for [%s] with course settings: %s', self.__str__(), course_settings)
         log_details = {
-            'request_payload': json_data,
+            'request_payload': enrollment_data,
             'url': url,
             'course_advanced_settings': course_settings,
         }
@@ -128,6 +130,7 @@ class GreenfigInstanceExternalEnrollment(BaseExternalEnrollment):
                 request_type=str(self),
                 details=log_details,
             )
+
             return str(error), status.HTTP_400_BAD_REQUEST
         else:
             json_response = self._get_json_response(response)

--- a/openedx_external_enrollments/external_enrollments/greenfig_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/greenfig_external_enrollment.py
@@ -98,3 +98,45 @@ class GreenfigInstanceExternalEnrollment(BaseExternalEnrollment):
             return str(error), status.HTTP_500_INTERNAL_SERVER_ERROR
         else:
             return response
+
+    def _post_enrollment(self, data, course_settings=None):
+        """
+        Get request data and execute the post request.
+        """
+        url = self._get_enrollment_url(course_settings)
+        json_data = self._get_enrollment_data(data, course_settings)
+        LOG.info('calling enrollment for [%s] with data: %s', self.__str__(), json_data)
+        LOG.info('calling enrollment for [%s] with url: %s', self.__str__(), url)
+        LOG.info('calling enrollment for [%s] with course settings: %s', self.__str__(), course_settings)
+        log_details = {
+            'request_payload': json_data,
+            'url': url,
+            'course_advanced_settings': course_settings,
+        }
+
+        try:
+            response = self._execute_post(
+                url=url,
+                headers=self._get_enrollment_headers(),
+                json_data=json_data,
+            )
+        except Exception as error:  # pylint: disable=broad-except
+            log_details['response'] = {'error': 'Failed to complete enrollment. Reason: %s' % str(error)}
+
+            LOG.error('Failed to complete enrollment. Reason: %s', str(error))
+            EnrollmentRequestLog.objects.create(  # pylint: disable=no-member
+                request_type=str(self),
+                details=log_details,
+            )
+            return str(error), status.HTTP_400_BAD_REQUEST
+        else:
+            json_response = self._get_json_response(response)
+            log_details['response'] = json_response
+
+            LOG.info('External enrollment response for [%s] -- %s', self.__str__(), json_response)
+            EnrollmentRequestLog.objects.create(  # pylint: disable=no-member
+                request_type=str(self),
+                details=log_details,
+            )
+
+            return json_response, status.HTTP_200_OK

--- a/openedx_external_enrollments/tests/external_enrollments/test_greenfig_external_enrollment.py
+++ b/openedx_external_enrollments/tests/external_enrollments/test_greenfig_external_enrollment.py
@@ -29,8 +29,10 @@ class GreenfigInstanceExternalEnrollmentTest(TestCase):
         course_settings = {
             'external_course_run_id': 'course_id+10',
         }
-        expected_data = u'08-04-2020 10:50:34, John Doe, John, Doe, johndoe@email.com, course_id+10, true\n'
-        expected_data += u'08-04-2020 10:50:34, Mary Brown, Mary, Brown, marybrown@email.com, course_id+10, true\n'
+        dropbox_response_text = '08-04-2020 10:50:34, John Doe, John, Doe, johndoe@email.com, course_id+10, true\n'
+        expected_enrollment_data = '08-04-2020 10:50:34, Mary Brown, Mary, Brown, '\
+                                   'marybrown@email.com, course_id+10, true\n'
+        expected_file_data = dropbox_response_text + expected_enrollment_data
         user = Mock()
         user.first_name = 'Mary'
         user.last_name = 'Brown'
@@ -39,12 +41,12 @@ class GreenfigInstanceExternalEnrollmentTest(TestCase):
         get_user_mock.return_value = (user, '')
         datetime_now_mock.now.return_value.strftime.return_value = '08-04-2020 10:50:34'
         dropbox_response = Mock()
-        dropbox_response.text = u'08-04-2020 10:50:34, John Doe, John, Doe, johndoe@email.com, course_id+10, true\n'
+        dropbox_response.text = dropbox_response_text
         _get_course_list_mock.return_value = dropbox_response
 
         self.assertEqual(
             self.base._get_enrollment_data(data, course_settings),  # pylint: disable=protected-access
-            expected_data,
+            (expected_file_data, expected_enrollment_data)
         )
 
     def test_get_enrollment_url_default_settings(self):


### PR DESCRIPTION
# Description:
Currently, the Greenfig integration saves the entire content of the enrollment log file in every `EnrollmentRequestLog` object, It should only contain information relating to the enrollment event that triggered the the Greenfig controller.
