### PR TITLE
PAE-764.2 -  Update and improve SF integration.

### DIFF
--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -226,6 +226,14 @@ class SalesforceEnrollment(BaseExternalEnrollment):
             "Secondary_Source",
             "",
         )
+        program_of_interest["Type_Hidden"] = program_of_interest.get(
+            "Type_Hidden",
+            "",
+        )
+        program_of_interest["Company"] = program_of_interest.get(
+            "Company",
+            "",
+        )
 
         return program_of_interest
 
@@ -312,8 +320,11 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                     course_data["Institution_Hidden"] = poi_data.get("Institution_Hidden", ih_from_course)
                     course_data["Program_of_Interest"] = poi_data.get("Program_of_Interest", poi_from_course)
 
-            except Exception:  # pylint: disable=broad-except
-                pass
+            except AttributeError as error:
+                LOG.error('Course [{}] is not properly configured. Reason: [{}]'.format(
+                    course_id,
+                    str(error),
+                ))
             else:
                 courses.append(course_data)
 


### PR DESCRIPTION
## Description:
The main objective of this PR is to address the following former behavior of `_get_program_of_interest_data` method during a **program purchase**:

1. When conducting a program purchase with non-existing `ProgramSalesforceEnrollment` instance for the bundle/program associated with the purchase, `_get_program_of_interest_data` didn't return any of the top level SF settings (Drupal_ID, Lead_Source, UTM_Parameters, Secondary_Source)

This PR involves the following changes:

-  `_get_program_of_interest_data` is renamed as  `_get_salesforce_settings`, to avoid confusion.
- `_get_salesforce_settings` returns its data from course/program (which depends on the case) and still populates Lead_Source and Secondary_Source
-  `_get_salesforce_data` is now on charge of this variables UTM_Parameters and Drupal_ID.
-  `_get_program_of_interest_from_program` is introduced to be called to use its variables such as Institution_Hidden and Program_of_Interest.
- `_get_courses_data` has a logging mechanism , which helps us indicating when a course is not properly configured (Missing advance course settings/other_course_settings or missing course end date).

Ticket: [PAE-764](https://pearsonadvance.atlassian.net/browse/PAE-764)
### Note:
There are still some improvements to address. For example: when there is a program purchase the `ProgramSalesforceEnrollment` is retrieved twice.