### PR TITLE
Upgrade versions requirements to keep the same as the edx-platform (lilac)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.5, 3.8 ]
+        python-version: [ 3.6, 3.8 ]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 3.11.2 - October 14, 2021
+**Changes:**
+
+  - Improve SF Integration.
+
 ### Version 3.11.1 - October 04, 2021
 **Changes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 3.11.3 - December 2, 2021
+**Changes:**
+
+  - Update Greenfig Integration.
+
 ### Version 3.11.2 - October 14, 2021
 **Changes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 3.11.0 - September 27, 2021
+**Changes:**
+
+  - Update SF API payload.
+
 ### Version 3.10.1 - September 16, 2021
 **Changes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 3.11.1 - October 04, 2021
+**Changes:**
+
+  - Fix SF API payload according to new conditions.
+
 ### Version 3.11.0 - September 27, 2021
 **Changes:**
 

--- a/openedx_external_enrollments/__init__.py
+++ b/openedx_external_enrollments/__init__.py
@@ -4,4 +4,4 @@ Init module for openedx_external_enrollments.
 
 from __future__ import unicode_literals
 
-__version__ = '3.11.0'
+__version__ = '3.11.1'

--- a/openedx_external_enrollments/__init__.py
+++ b/openedx_external_enrollments/__init__.py
@@ -4,4 +4,4 @@ Init module for openedx_external_enrollments.
 
 from __future__ import unicode_literals
 
-__version__ = '3.11.2'
+__version__ = '3.11.3'

--- a/openedx_external_enrollments/__init__.py
+++ b/openedx_external_enrollments/__init__.py
@@ -4,4 +4,4 @@ Init module for openedx_external_enrollments.
 
 from __future__ import unicode_literals
 
-__version__ = '3.11.1'
+__version__ = '3.11.2'

--- a/openedx_external_enrollments/__init__.py
+++ b/openedx_external_enrollments/__init__.py
@@ -4,4 +4,4 @@ Init module for openedx_external_enrollments.
 
 from __future__ import unicode_literals
 
-__version__ = '3.10.1'
+__version__ = '3.11.0'

--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -142,20 +142,31 @@ class SalesforceEnrollment(BaseExternalEnrollment):
         """
         salesforce_data = {}
         order_lines = data.get("supported_lines")
-        if order_lines:
-            try:
-                salesforce_data.update(self._get_program_of_interest_data(data, order_lines))
-                salesforce_data["Order_Number"] = data.get("number")
-                salesforce_data["Purchase_Type"] = "Program" if data.get("program") else "Course"
-                salesforce_data["PaymentAmount"] = data.get("paid_amount")
-                salesforce_data["Amount_Currency"] = data.get("currency")
-            except Exception:  # pylint: disable=broad-except
-                pass
+        if not order_lines:
+            return salesforce_data
+
+        program = data.get("program")
+        email = order_lines[0].get("user_email")
+        openedx_user, _ = get_user(email=email)
+        try:
+            salesforce_data.update(self._get_salesforce_settings(data, order_lines))
+            salesforce_data["Order_Number"] = data.get("number")
+            salesforce_data["Purchase_Type"] = "Program" if program else "Course"
+            salesforce_data["PaymentAmount"] = data.get("paid_amount")
+            salesforce_data["Amount_Currency"] = data.get("currency")
+            salesforce_data["UTM_Parameters"] = data.get("utm_params", "")
+            salesforce_data["Drupal_ID"] = "enrollment+{}+{}+{}".format(
+                "program" if program else "course",
+                openedx_user.username,
+                datetime.datetime.utcnow().strftime("%Y/%m/%d-%H:%M:%S"),
+            )
+        except Exception:  # pylint: disable=broad-except
+            pass
 
         return salesforce_data
 
     def _get_program_of_interest_from_courses(self, order_lines):
-        """This method returns data from the first course with SF metadata."""
+        """This method returns SF settings data from the first course with SF metadata."""
         for line in order_lines:
             course = self._get_course(line.get("course_id"))
             program_of_interest = course.other_course_settings.get("salesforce_data")
@@ -163,51 +174,92 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                 return program_of_interest
         return {}
 
-    def _get_program_of_interest_data(self, data, order_lines):
+    def _get_salesforce_settings(self, data, order_lines):
         """
+        Return SF settings from course/program and the following data:
+        - Lead_Source
+        - Secondary_Source
+
+        Where the above data is retrieved depends on the case:
+
+        1. If program purchase and there is ProgramSalesforceEnrollment for the program with its
+        meta attribute populated, then the SF settings get pulled from this meta attribute.
+
+        2. If program purchase and does not exist a ProgramSalesforceEnrollment for the program,
+        then the SF settings get pulled from the first course with SF settings.
+
+        3. If program purchase and ProgramSalesforceEnrollment exists for the program but its meta
+        attribute is empty, then the SF settings get pulled from the first course with SF settings.
+
+        4. If course purchase, then the SF settings get pulled from the first course with SF
+        settings
 
         :param data:
         :param order_lines:
-        :return:
+        :return: (dict)
         """
         program_of_interest = {}
         program = data.get("program")
-        try:
-            email = order_lines[0].get("user_email")
-            openedx_user, _ = get_user(email=email)
-            request_time = datetime.datetime.utcnow()
-            if program:
-                bundle_id = program.get("uuid")
+
+        if program:
+            bundle_id = program.get("uuid")
+            try:
                 related_program = ProgramSalesforceEnrollment.objects.get(  # pylint: disable=no-member
                     bundle_id=bundle_id,
                 )
                 program_of_interest = related_program.meta
-                if not related_program.meta:
+                if not program_of_interest:
                     LOG.error('No meta in ProgramSalesforceEnrollment for bundle {}'.format(bundle_id))
+                    program_of_interest = {}
 
-            else:
-                program_of_interest = self._get_program_of_interest_from_courses(order_lines)
+            except ProgramSalesforceEnrollment.DoesNotExist:  # pylint: disable=no-member
+                LOG.error('ProgramSalesforceEnrollment not found for bundle [%s]', program.get("uuid"))
 
-            program_of_interest["Drupal_ID"] = "enrollment+{}+{}+{}".format(
-                "program" if program else "course",
-                openedx_user.username,
-                request_time.strftime("%Y/%m/%d-%H:%M:%S")
+        else:
+            program_of_interest = self._get_program_of_interest_from_courses(order_lines)
+
+        program_of_interest["Lead_Source"] = program_of_interest.get(
+            "Lead_Source",
+            "",
+        )
+        program_of_interest["Secondary_Source"] = program_of_interest.get(
+            "Secondary_Source",
+            "",
+        )
+        program_of_interest["Type_Hidden"] = program_of_interest.get(
+            "Type_Hidden",
+            "",
+        )
+        program_of_interest["Company"] = program_of_interest.get(
+            "Company",
+            "",
+        )
+
+        return program_of_interest
+
+    def _get_program_of_interest_from_program(self, data):
+        """
+        Retrieve the SF settings of the bundle/program associated with the purchase.
+
+        In case the purchase is not a program purchase, this method returns an empty dict. The
+        same happens when even if it is a program purchase but ProgramSalesForceEnrollment
+        does not exits for the bundle or its meta attribute is null, this method returns an
+        empty dict.
+        """
+        program_of_interest = {}
+        program = data.get("program")
+        if not program:
+            return program_of_interest
+
+        try:
+            bundle_id = program.get("uuid")
+            related_program = ProgramSalesforceEnrollment.objects.get(  # pylint: disable=no-member
+                bundle_id=bundle_id,
             )
-            program_of_interest["Lead_Source"] = program_of_interest.get(
-                "Lead_Source",
-                "",
-            )
-            program_of_interest["UTM_Parameters"] = data.get(
-                "utm_params",
-                "",
-            )
-            program_of_interest["Secondary_Source"] = program_of_interest.get(
-                "Secondary_Source",
-                "",
-            )
+            program_of_interest = related_program.meta
+            if not program_of_interest:
+                program_of_interest = {}
         except ProgramSalesforceEnrollment.DoesNotExist:  # pylint: disable=no-member
-            LOG.error('ProgramSalesforceEnrollment not found for bundle [%s]', program.get("uuid"))
-        except Exception:  # pylint: disable=broad-except
             pass
 
         return program_of_interest
@@ -244,6 +296,8 @@ class SalesforceEnrollment(BaseExternalEnrollment):
         :returns: courses (List of dicts):
         """
         courses = []
+        program_course_runs = self._get_program_course_runs(data)
+        poi_data = self._get_program_of_interest_from_program(data)
         for line in order_lines:
             try:
                 course_id = line.get("course_id")
@@ -262,17 +316,30 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                 course_data["Institution_Hidden"] = ih_from_course
                 course_data["Program_of_Interest"] = poi_from_course
 
-                if course_id in self._get_program_course_runs(data):
-                    poi_data = self._get_program_of_interest_data(data, order_lines)
+                if self._is_course_part_of_program(course_id, program_course_runs):
                     course_data["Institution_Hidden"] = poi_data.get("Institution_Hidden", ih_from_course)
                     course_data["Program_of_Interest"] = poi_data.get("Program_of_Interest", poi_from_course)
 
-            except Exception:  # pylint: disable=broad-except
-                pass
+            except AttributeError as error:
+                LOG.error('Course [{}] is not properly configured. Reason: [{}]'.format(
+                    course_id,
+                    str(error),
+                ))
             else:
                 courses.append(course_data)
 
         return courses
+
+    def _is_course_part_of_program(self, course_id, program_course_runs):
+        """This method checks whether or not a course is part of the program in the
+        purchase by comparing the course_runs which belong to the program.
+
+        :return: True if the course belongs to the program. False otherwise.
+        """
+        if course_id in program_course_runs:
+            return True
+
+        return False
 
     @staticmethod
     def _is_external_course(course):

--- a/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/salesforce_external_enrollment.py
@@ -250,6 +250,8 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                 course = self._get_course(course_id)
                 course_key = self._get_course_key(course_id)
                 salesforce_settings = course.other_course_settings.get("salesforce_data", {})
+                ih_from_course = salesforce_settings.get("Institution_Hidden", "")
+                poi_from_course = salesforce_settings.get("Program_of_Interest", "")
                 course_data = dict()
                 course_data["CourseName"] = salesforce_settings.get("Program_Name") or course.display_name
                 course_data["CourseID"] = "{}+{}".format(course_key.org, course_key.course)
@@ -257,13 +259,13 @@ class SalesforceEnrollment(BaseExternalEnrollment):
                 course_data["CourseStartDate"] = self._get_course_start_date(course, line.get("user_email"), course_id)
                 course_data["CourseEndDate"] = course.end.strftime("%Y-%m-%d")
                 course_data["CourseDuration"] = "0"
-                course_data["Institution_Hidden"] = salesforce_settings.get("Institution_Hidden", "")
-                course_data["Program_of_Interest"] = salesforce_settings.get("Program_of_Interest", "")
+                course_data["Institution_Hidden"] = ih_from_course
+                course_data["Program_of_Interest"] = poi_from_course
 
                 if course_id in self._get_program_course_runs(data):
                     poi_data = self._get_program_of_interest_data(data, order_lines)
-                    course_data["Institution_Hidden"] = poi_data["Institution_Hidden"]
-                    course_data["Program_of_Interest"] = poi_data["Program_of_Interest"]
+                    course_data["Institution_Hidden"] = poi_data.get("Institution_Hidden", ih_from_course)
+                    course_data["Program_of_Interest"] = poi_data.get("Program_of_Interest", poi_from_course)
 
             except Exception:  # pylint: disable=broad-except
                 pass

--- a/openedx_external_enrollments/tests/external_enrollments/test_greenfig_external_enrollment.py
+++ b/openedx_external_enrollments/tests/external_enrollments/test_greenfig_external_enrollment.py
@@ -29,8 +29,10 @@ class GreenfigInstanceExternalEnrollmentTest(TestCase):
         course_settings = {
             'external_course_run_id': 'course_id+10',
         }
-        expected_data = u'08-04-2020 10:50:34, John Doe, John, Doe, johndoe@email.com, course_id+10, true\n'
-        expected_data += u'08-04-2020 10:50:34, Mary Brown, Mary, Brown, marybrown@email.com, course_id+10, true\n'
+        dropbox_response_text = '08-04-2020 10:50:34, John Doe, John, Doe, johndoe@email.com, course_id+10, true\n'
+        expected_enrollment_data = '08-04-2020 10:50:34, Mary Brown, Mary, Brown, '\
+                                   'marybrown@email.com, course_id+10, true\n'
+        expected_file_data = dropbox_response_text + expected_enrollment_data
         user = Mock()
         user.first_name = 'Mary'
         user.last_name = 'Brown'
@@ -39,12 +41,12 @@ class GreenfigInstanceExternalEnrollmentTest(TestCase):
         get_user_mock.return_value = (user, '')
         datetime_now_mock.now.return_value.strftime.return_value = '08-04-2020 10:50:34'
         dropbox_response = Mock()
-        dropbox_response.text = u'08-04-2020 10:50:34, John Doe, John, Doe, johndoe@email.com, course_id+10, true\n'
+        dropbox_response.text = dropbox_response_text
         _get_course_list_mock.return_value = dropbox_response
 
         self.assertEqual(
             self.base._get_enrollment_data(data, course_settings),  # pylint: disable=protected-access
-            expected_data,
+            (expected_file_data, expected_enrollment_data)
         )
 
     def test_get_enrollment_url_default_settings(self):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,8 +3,8 @@
 
 celery
 Django
-djangorestframework==3.9.4
-edx-opaque-keys==2.1.0
+djangorestframework==3.12.4
+edx-opaque-keys==2.2.0
 jsonfield2
 oauthlib
 requests-oauthlib

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,9 +13,9 @@ celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements
 certifi==2021.5.30        # via requests
 chardet==3.0.4            # via requests
 django==2.2.24            # via -c requirements/constraints.txt, -r requirements/base.in, jsonfield2
-djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in
+djangorestframework==3.12.4  # via -c requirements/constraints.txt, -r requirements/base.in
 docutils==0.17.1          # via botocore
-edx-opaque-keys==2.1.0    # via -c requirements/constraints.txt, -r requirements/base.in
+edx-opaque-keys==2.2.0    # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.10                # via requests
 jmespath==0.10.0          # via boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
@@ -26,7 +26,7 @@ pymongo==3.12.0           # via edx-opaque-keys
 python-dateutil==2.8.2    # via botocore
 pytz==2021.1              # via celery, django
 requests-oauthlib==1.3.0  # via -r requirements/base.in
-requests==2.23.0          # via -c requirements/constraints.txt, -r requirements/base.in, requests-oauthlib
+requests==2.25.1          # via -c requirements/constraints.txt, -r requirements/base.in, requests-oauthlib
 s3transfer==0.1.13        # via boto3
 six==1.16.0               # via edx-opaque-keys, python-dateutil, stevedore
 sqlparse==0.4.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,15 +19,15 @@ celery>=3.1.25,<4.0.0
 Django<2.3
 
 # Keep same platform version
-djangorestframework==3.9.4
+djangorestframework==3.12.4
 jsonfield2<3.1.0
 oauthlib==3.0.1
-pip-tools<5.0.0
-edx-opaque-keys==2.1.0
+pip-tools<5.4
+edx-opaque-keys==2.2.0
 astroid==2.3.3
 boto3==1.4.8
 botocore==1.8.17
-requests==2.23.0
+requests==2.25.1
 
 # 5.0.0 dropped support for Python 3.5
 isort<5.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,9 +15,9 @@ chardet==3.0.4            # via -r requirements/base.txt, requests
 coverage==5.5             # via -r requirements/test.in
 ddt==1.4.2                # via -r requirements/test.in
 django==2.2.24            # via -c requirements/constraints.txt, -r requirements/base.txt, jsonfield2
-djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt
+djangorestframework==3.12.4  # via -c requirements/constraints.txt, -r requirements/base.txt
 docutils==0.17.1          # via -r requirements/base.txt, botocore
-edx-opaque-keys==2.1.0    # via -c requirements/constraints.txt, -r requirements/base.txt
+edx-opaque-keys==2.2.0    # via -c requirements/constraints.txt, -r requirements/base.txt
 idna==2.10                # via -r requirements/base.txt, requests
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -29,7 +29,7 @@ pymongo==3.12.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.2    # via -r requirements/base.txt, botocore
 pytz==2021.1              # via -r requirements/base.txt, celery, django
 requests-oauthlib==1.3.0  # via -r requirements/base.txt
-requests==2.23.0          # via -c requirements/constraints.txt, -r requirements/base.txt, requests-oauthlib
+requests==2.25.1          # via -c requirements/constraints.txt, -r requirements/base.txt, requests-oauthlib
 s3transfer==0.1.13        # via -r requirements/base.txt, boto3
 six==1.16.0               # via -r requirements/base.txt, edx-opaque-keys, mock, python-dateutil, stevedore
 sqlparse==0.4.1           # via -r requirements/base.txt, django

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.1
+current_version = 3.11.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.11.1
+current_version = 3.11.2
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.11.2
+current_version = 3.11.3
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.11.0
+current_version = 3.11.1
 commit = True
 tag = True
 


### PR DESCRIPTION
This PR is to upgrade the version of djangorestfamework, edx-opaque-keys and requests so that when running `pip install -e /path/to/your/src/folder` in the Lms/Devstack shell, it does not generate any problem.

it is important to mention that if you run `pip install -e /path/to/your/src/folder` on the juniper version, you will get an error since this has the edx-submissions version `3.1.7` and the lilac version has `3.2.4`.

The version of Python to GitHub Actions also need to upgrade from `3.5` to `3.6` due to version of edx-opaque-keys. 